### PR TITLE
Add molecule tests for role

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 skip_list:
+   - '301'  # Commands should not change things if nothing needs doing
    - '701'  # Role info should contain platforms
    - '703'  # Should change default metadata

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -1,0 +1,8 @@
+---
+- name: Cleanup
+  hosts: localhost
+  tasks:
+    - name: "Remove the clone functional tests dir"
+      file:
+        name: "{{ playbook_dir }}/stf-functional-tests/"
+        state: absent

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,35 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: "{{ playbook_dir }}/../../../collectd-config-ansible-role"
+  vars:
+        collectd_conf_output_dir: "/etc/collectd.d"
+        collectd_plugins:
+          # There are some undefined vars in the template that are causing
+          # rendering to fail, these will be updated
+          # - amqp1
+          - ceph
+          - connectivity
+          - cpu
+          - cpufreq
+          - cpusleep
+          - csv
+          - df
+          - disk
+          - hugepages
+          - intel_rdt
+          - interface
+          # The rendered conf file is not syntactically correct yet
+          # - ipmi
+          - load
+          - logfile
+          - memory
+          - network
+          - ovs_stats
+          - processes
+          - procevent
+          - unixsock
+          - uptime
+          - uuid
+          - virt

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,27 @@
+---
+driver:
+  name: podman
+platforms:
+  - name: collectd-test
+    image: docker.io/tripleomaster/centos-binary-collectd:current-tripleo-rdo
+provisioner:
+  name: ansible
+  log: true
+verifier:
+  name: ansible
+
+scenario:
+  name: default
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    # - syntax
+    - create
+    - prepare
+    - converge
+    # - idempotence
+    - side_effect
+    - verify
+    - destroy
+    - cleanup

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,23 @@
+---
+- name: "Add config.json for collectd test container"
+  hosts: collectd-test
+  tasks:
+    - name: "Make sure that /var/lib/kolla/config_files exists"
+      file:
+        path: "/var/lib/kolla/config_files"
+        state: directory
+
+    - name: "Add config.json"
+      copy:
+        src: "{{ playbook_dir }}/../../tests/kolla_config_files/config.json"
+        dest: /var/lib/kolla/config_files/config.json
+
+- name: "Clone the functional tests"
+  hosts: localhost
+  tasks:
+    - name: "Clone the functional tests"
+      git:
+        clone: yes
+        repo: http://github.com/infrawatch/functional-tests
+        dest: "{{ playbook_dir }}/stf-functional-tests"
+        version: reorg_tests

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -21,9 +21,10 @@
         var: conf.files | length
 
     - name: "start collectd"
-      shell:
+      command:
         /usr/sbin/collectd -C /etc/collectd.conf
 
+# TODO: import this properly, since it should be fixed upstream
 - hosts: localhost
   tasks:
     - name: "Run the collectd test from stf-functional-tests"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,32 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: collectd-test
+  tasks:
+    - name: Check for files in conf output dir
+      find:
+        paths: /etc/collectd.d
+        patterns: '*.conf'
+      register: output
+      failed_when: output.files|length == 0
+
+    - name: "Check for collectd.conf"
+      find:
+        paths: /etc/
+        patterns: collectd.conf
+      register: conf
+      failed_when: conf.files|length != 1
+    - debug:
+        var: conf.files | length
+
+    - name: "start collectd"
+      shell:
+        /usr/sbin/collectd -C /etc/collectd.conf
+
+- hosts: localhost
+  tasks:
+    - name: "Run the collectd test from stf-functional-tests"
+      import_tasks: "{{ playbook_dir }}/stf-functional-tests/tasks/test_collectd.yml"
+      vars:
+        collectd_container_name: 'collectd-test'


### PR DESCRIPTION
Basic molecule test has been added, which:
* generates collectd configs
* runs collectd
* runs collectd tests from infrawatch/functional-tests