### PR TITLE
Add 2 scripts to make local test builds easier

### DIFF
--- a/tests/test-buildah.sh
+++ b/tests/test-buildah.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+base=$(buildah from "${1:-fedora}")
+
+## install Ansible
+buildah run "$base" -- dnf install ansible -y
+
+buildah config --annotation "watch.infra.build.host=$(uname -n)" "$base"
+
+buildah config --cmd "/usr/bin/ansible-playbook -i /collectd-config-ansible-role/tests/inventory /collectd-config-ansible-role/tests/test.yml" "$base"
+
+buildah commit "$base" "${2:-ansible-config-tester}"

--- a/tests/test-runner.sh
+++ b/tests/test-runner.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+REL=$(dirname "$0")
+podman run -it -v ${REL}/../:/collectd-config-ansible-role/ localhost/ansible-config-tester
+
+# TODO: does not currently clean up after itself


### PR DESCRIPTION
Add 2 scripts for local testing without needing a separate environment:

* test-buildah.sh: uses buildah to builda a Fedora container image with Ansible installed locally
* test-runner.sh: uses podman to mount local directory and run test.yml with ansible-playbook
