### PR TITLE
[molecule] Install the stf functional-tests properly

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,4 +1,7 @@
 ---
+dependency:
+  roles:
+    - git+https://github.com/infrawatch/functional-tests
 driver:
   name: podman
 platforms:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -11,13 +11,3 @@
       copy:
         src: "{{ playbook_dir }}/../../tests/kolla_config_files/config.json"
         dest: /var/lib/kolla/config_files/config.json
-
-- name: "Clone the functional tests"
-  hosts: localhost
-  tasks:
-    - name: "Clone the functional tests"
-      git:
-        clone: yes
-        repo: http://github.com/infrawatch/functional-tests
-        dest: "{{ playbook_dir }}/stf-functional-tests"
-        version: reorg_tests

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,6 +1,4 @@
 ---
-# This is an example playbook to execute Ansible tests.
-
 - name: Verify
   hosts: collectd-test
   tasks:
@@ -24,10 +22,11 @@
       command:
         /usr/sbin/collectd -C /etc/collectd.conf
 
-# TODO: import this properly, since it should be fixed upstream
 - hosts: localhost
   tasks:
-    - name: "Run the collectd test from stf-functional-tests"
-      import_tasks: "{{ playbook_dir }}/stf-functional-tests/tasks/test_collectd.yml"
+    - name: "Run the collectd test from STF functional-tests"
+      include_role:
+        name: functional-tests
+        tasks_from: test_collectd
       vars:
         collectd_container_name: 'collectd-test'


### PR DESCRIPTION
Use galaxy for dependency management and include_role instead of
git clone into the current repo and import task.