### PR TITLE
[hugepages] Make the plugin configurable

### DIFF
--- a/defaults/main/hugepages.yml
+++ b/defaults/main/hugepages.yml
@@ -1,0 +1,6 @@
+---
+collectd_plugin_hugepages_report_per_node_hp: true 
+collectd_plugin_hugepages_report_root_hp: true
+collectd_plugin_hugepages_values_pages: true
+collectd_plugin_hugepages_values_bytes: false
+collectd_plugin_hugepages_values_percentage: false

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -22,6 +22,11 @@
       command:
         /usr/sbin/collectd -C /etc/collectd.conf
 
+    - name: "Check for metrics from different plugins"
+      shell: |
+        set -o pipefail
+        collectdctl -s /var/run/collectd-socket listval | grep hugepages
+
 - hosts: localhost
   tasks:
     - name: "Run the collectd test from STF functional-tests"

--- a/templates/hugepages.conf.j2
+++ b/templates/hugepages.conf.j2
@@ -1,9 +1,9 @@
 LoadPlugin hugepages
 
-<Plugin hugepages>
-  ReportPerNodeHP true
-  ReportRootHP true
-  ValuesPages true
-  ValuesBytes false
-  ValuesPercentage false
+<Plugin "hugepages">
+  ReportPerNodeHP {{ collectd_plugin_hugepages_report_per_node_hp }}
+  ReportRootHP {{ collectd_plugin_hugepages_report_root_hp }}
+  ValuesPages {{ collectd_plugin_hugepages_values_pages }}
+  ValuesBytes {{ collectd_plugin_hugepages_values_bytes }}
+  ValuesPercentage {{ collectd_plugin_hugepages_values_percentage }}
 </Plugin>


### PR DESCRIPTION
* Adds variable config values for hugepages.conf.j2
* Sets defaults for the values
* Updates molecule test to make sure metrics are created

To test  "configurability" of hugepages .conf, use

ansible-playbook -i tests/inventory tests/test.yml -e collectd_conf_output_dir=_**"/path/to/conf_dir/collectd_config/confs"**_ -e collectd_plugin_hugepages_**XXXX="False"**_  && cat "_**/path/to/conf_dir/collectd_config/confs**_/hugepages.conf

and change the highlighted pieces