### PR TITLE
[molecule] Kill collectd before starting in verify

### DIFF
--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -18,9 +18,16 @@
     - debug:
         var: conf.files | length
 
-    - name: "start collectd"
-      command:
-        /usr/sbin/collectd -C /etc/collectd.conf
+    - name: "(Re)start collectd"
+      block:
+        - name: "Kill running collectd process"
+          command:
+            pkill -e -c collectd
+          ignore_errors: true
+
+        - name: "Start collectd"
+          command:
+            /usr/sbin/collectd -C /etc/collectd.conf
 
 - hosts: localhost
   tasks:


### PR DESCRIPTION
When using converge and verify steps multiple times without
destroying the test container (e.g. when developing the role),
multiple collectd processes will be started.
This change kills existing processes before starting collectd
to load the new config.