### PR TITLE
[test_network] Change retry criteria for checking network

### DIFF
--- a/molecule/test_network/verify.yml
+++ b/molecule/test_network/verify.yml
@@ -34,8 +34,11 @@
     - name: "Check for metrics received by the collectd server"
       command:
         collectdctl -s /var/run/collectd-socket listval
+      retries: 3
+      delay: 5
       register: plugins
-      failed_when: ( plugins.stdout_lines|length == 0 ) or ( plugins.stderr | length > 0 )
+      until: plugins.stdout_lines | length > 0
+      failed_when: ( plugins.stderr | length > 0 ) or ( plugins.rc != 0 )
 
     - name: "Check that collectd-test is reporting network stats (collectd_plugin_network_reportstats: True)"
       assert:


### PR DESCRIPTION
The retry module is used for checking whether the network
plugin is set up correctly in order to compensate for
delays in generating, sending and receiving metrics.

The task parameters were updated so that the failure happend
with a non-zero rc, and the task continues to retry until
there is a list of metrics (i.e. stdout_lines|len != 0), or
the retry counter runs out.
Previously, the retry counter wouldn't get past the first
iteration due to incorrect failure criteria.