### PR TITLE
[virt] Remove quotes on HostnameFormat

### DIFF
--- a/templates/virt.conf.j2
+++ b/templates/virt.conf.j2
@@ -31,7 +31,7 @@ LoadPlugin virt
   BlockDeviceFormatBasename {{ collectd_plugin_virt_blockdeviceformatbasename }}
 {% endif %}
 {% if collectd_plugin_virt_hostnameformat is defined %}
-  HostnameFormat "{{ collectd_plugin_virt_hostnameformat }}"
+  HostnameFormat {{ collectd_plugin_virt_hostnameformat }}
 {% endif %}
 {% if collectd_plugin_virt_interfaceformat is defined %}
   InterfaceFormat "{{ collectd_plugin_virt_interfaceformat }}"


### PR DESCRIPTION
Update template for virt plugin to add quotes around HostnameFormat