### PR TITLE
[dcpmm] Add template for the dcpmm plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,16 @@ See the collectd `wiki <https://collectd.org/wiki/index.php/Plugin:capabilities>
 collectd_plugin_capabilities_host: localhost
 collectd_plugin_capabilities_port: "9104"
 
+collectd_plugin_dcpmm_*
+~~~~~~~~~~~~~~~~~~~~~~~
+These vars are ones passed to the ``dcpmm`` plugin.
+See the collectd `config guide <https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_dcpmm>`_ for details.
+
+collectd_plugin_dcpmm_interval: 10.0
+collectd_plugin_dcpmm_collect_health: False
+collectd_plugin_dcpmm_collect_perf_metrics: True
+collectd_plugin_dcpmm_enable_dispatch_all: False
+
 collectd_plugin_ethstat_*
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 These vars are ones passed to the ``ethstat`` plugin.

--- a/templates/dcpmm.conf.j2
+++ b/templates/dcpmm.conf.j2
@@ -1,0 +1,16 @@
+LoadPlugin dcpmm
+
+<Plugin "dcpmm">
+{% if collectd_plugin_dcpmm_interval is defined %}
+  Interval {{ collectd_plugin_dcpmm_interval }}
+{% endif %}
+{% if collectd_plugin_dcpmm_collect_health is defined %}
+  CollectdHealth {{ collectd_plugin_dcpmm_collect_health }}
+{% endif %}
+{% if collectd_plugin_dcpmm_collect_perf_metrics is defined %}
+  CollectPerfMetrics {{ collectd_plugin_dcpmm_collect_perf_metrics }}
+{% endif %}
+{% if collectd_plugin_dcpmm_enable_dispatch_all is defined %}
+  EnableDispatchAll {{ collectd_plugin_dcpmm_enable_dispatch_all }}
+{% endif %}
+</Plugin>


### PR DESCRIPTION
Template included for the dcpmm plugin.
All the config values are optional, and so there is no
default/main/dcpmm.yml included.
Config values are documented in README.rst

Support for dcpmm plugin is not yet included in the container used for
testing with molecule, so tests are not included.
Once the container supports dcpmm, then the plugin config can be tested
by modifying the plugin lists in tests/test.yml and
molecule/default/converge.yml.