### PR TITLE
[mdevents] Add template for the mdeventsplugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,16 @@ collectd_plugin_irq_irq:
    - 8
    - 9
 
+collectd_plugin_mdevents_*
+~~~~~~~~~~~~~~~~~~~~~~~~~
+These vars are ones passed to the ``mdevents`` plugin.
+See the collectd `config guide <https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_mdevents>`_ for details.
+
+collectd_plugin_mdevents_event: "DeviceDisappeared Fail DegradedArray"
+collectd_plugin_mdevents_ignore_event: False
+collectd_plugin_mdevents_array: "/dev/md[0-9]"
+collectd_plugin_mdevents_ignore_array: False
+
 collectd_plugin_ovs_stats_*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/templates/mdevents.conf.j2
+++ b/templates/mdevents.conf.j2
@@ -1,0 +1,22 @@
+{% if collectd_plugin_mdevents_interval is not defined %}
+LoadPlugin mdevents
+{% else %}
+<LoadPlugin mdevents>
+   Interval {{ collectd_plugin_mdevents_interval }}
+</LoadPlugin>
+{% endif %}
+
+<Plugin "mdevents">
+{% if collectd_plugin_mdevents_event is defined %}
+  Event "{{ collectd_plugin_mdevents_event }}"
+{% endif %}
+{% if collectd_plugin_mdevents_ignore_event is defined %}
+  IgnoreEvent {{ collectd_plugin_mdevents_ignore_event | string | lower }}
+{% endif %}
+{% if collectd_plugin_mdevents_array is defined %}
+  Array "{{ collectd_plugin_mdevents_array }}"
+{% endif %}
+{% if collectd_plugin_mdevents_ignore_array is defined %}
+  IgnoreArray {{ collectd_plugin_mdevents_ignore_array | string | lower }}
+{% endif %}
+</Plugin>


### PR DESCRIPTION
Template included for the mdevents plugin.
All the config values are optional, and so there is no
default/main/mdevents.yml included.
Config values are documented in README.rst

Support for mdevents plugin is not yet included in the container used for
testing with molecule, so tests are not included.
Once the container supports mdevents, then the plugin config can be tested
by modifying the plugin lists in tests/test.yml and
molecule/default/converge.yml.