### PR TITLE
[mcelog] Add template for mcelog plugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,23 @@ collectd_plugin_irq_irq:
    - 8
    - 9
 
+collectd_plugin_mcelog_*
+~~~~~~~~~~~~~~~~~~~~~~~~~
+These vars are ones passed to the ``mcelog`` plugin.
+See the collectd `config guide <https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_mcelog>`_ for details.
+
+::
+  collectd_plugin_mcelog_mceloglogfile: "/var/log/mcelog"
+  collectd_plugin_mcelog_memory:
+    mcelogclientsocket: "/var/run/mcelog-client"
+    persistentnotification: False
+
+.. NOTE::
+
+  The two config options (``collectd_plugin_mcelog_mceloglogfile`` and
+  ``collectd_plugin_mcelog_memory`` are mutually exclusive in collectd.
+  Collectd will complain about this, however this role will not.
+
 collectd_plugin_mdevents_*
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 These vars are ones passed to the ``mdevents`` plugin.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -34,6 +34,7 @@
           - irq
           - load
           - logfile
+          - mcelog
           - memory
           - netlink
           - network

--- a/templates/mcelog.conf.j2
+++ b/templates/mcelog.conf.j2
@@ -1,0 +1,23 @@
+{% if collectd_plugin_mcelog_interval is not defined %}
+LoadPlugin mcelog
+{% else %}
+<LoadPlugin mcelog>
+   Interval {{ collectd_plugin_mcelog_interval }}
+</LoadPlugin>
+{% endif %}
+
+<Plugin "mcelog">
+{% if collectd_plugin_mcelog_mceloglogfile is defined %}
+  McelogLogfile "{{ collectd_plugin_mcelog_mceloglogfile }}"
+{% endif %}
+{% if collectd_plugin_mcelog_memory is defined %}
+  <Memory>
+{% if collectd_plugin_mcelog_memory["mcelogclientsocket"] | default() is defined %}
+    McelogClientSocket "{{ collectd_plugin_mcelog_memory["mcelogclientsocket"] }}"
+{% endif %}
+{% if collectd_plugin_mcelog_memory["persistentnotification"] | default() is defined %}
+    PersistentNotification {{ collectd_plugin_mcelog_memory["persistentnotification"] }}
+{% endif %}
+  </Memory>
+{% endif %}
+</Plugin>

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -26,6 +26,7 @@
         - irq
         - load
         # - logfile
+        - mcelog
         - memory
         - netlink
         - network


### PR DESCRIPTION
Template included for the mcelog plugin.
All the config values are optional, and so there is no
default/main/mcelog.yml included.
Config values are documented in README.rst