### PR TITLE
[dpdk_telemetry] Add template for dpdk_telemetry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,6 +180,16 @@ See the collectd `config guide <https://collectd.org/documentation/manpages/coll
   collectd_plugin_dns_ignoresource: 123.45.67.89
   collectd_plugin_dns_selectnumericquerytypes: True
 
+collectd_plugin_dpdk_telemetry_*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These vars are ones passed to the ``dpdk_telemetry`` plugin.
+See the collectd `config guide <https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_dpdk_telemetry>`_ for details.
+
+::
+
+  collectd_plugin_dpdk_telemetry_client_socket_path: "/var/run/.client"
+  collectd_plugin_dpdk_telemetry_dpdk_socket_path: "/var/run/dpdk/rte/telemetry"
+
 collectd_plugin_ethstat_*
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 These vars are ones passed to the ``ethstat`` plugin.

--- a/molecule/common/prepare.yml
+++ b/molecule/common/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: "Set up OpsTools repo to get collectd-* packages"
+      yum_repository:
+        name: centos-opstools-release
+        description: CentOS OpsTools
+        baseurl: http://mirror.centos.org/centos/8/opstools/x86_64/collectd-5
+        gpgcheck: no

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -23,6 +23,7 @@
           # - dcpmm
           - df
           - disk
+          - dpdk_telemetry
           - dns
           - ethstat
           - exec

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,10 @@
+---
+- import_playbook: ../common/prepare.yml
+
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: "Install extra packages for plugins not included in the image"
+      package:
+        name:
+          - collectd-dpdk_telemetry

--- a/templates/dpdk_telemetry.conf.j2
+++ b/templates/dpdk_telemetry.conf.j2
@@ -1,0 +1,16 @@
+{% if collectd_plugin_dpdk_telemetry_interval is not defined %}
+LoadPlugin dpdk_telemetry
+{% else %}
+<LoadPlugin dpdk_telemetry>
+   Interval {{ collectd_plugin_dpdk_telemetry_interval }}
+</LoadPlugin>
+{% endif %}
+
+<Plugin "dpdk_telemetry">
+{% if collectd_plugin_dpdk_telemetry_client_socket_path is defined %}
+  ClientSocketPath "{{ collectd_plugin_dpdk_telemetry_client_socket_path }}"
+{% endif %}
+{% if collect_plugin_dpdk_telemetry_dpdk_socket_path is defined %}
+  DpdkSocketPath "{{ collectd_plugin_dpdk_telemetry_dpdk_socket_path }}"
+{% endif %}
+</Plugin>


### PR DESCRIPTION
Config values are documented in README.rst

Support for dpdk_telemetry plugin is not yet included in the container used for
testing with molecule, so tests are not included.
Once the container supports dpdk_telemetry, then the plugin config can be tested
by modifying the plugin lists in tests/test.yml and
molecule/default/converge.yml.