### PR TITLE
Add custom types.db files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         scenario:
           - default
+          - extra_typesdb
           - test_network
-
     env:
       PY_COLORS: '1'
       ANSIBLE_FORCE_COLOR: '1'

--- a/defaults/main/00_misc_vars.yml
+++ b/defaults/main/00_misc_vars.yml
@@ -28,3 +28,4 @@ collectd_recurse: true
 collectd_minimum_version: true
 
 collectd_conf_output_dir: "/etc/collectd.conf.d/"
+collectd_typesdb_extra: []

--- a/molecule/extra_typesdb/converge.yml
+++ b/molecule/extra_typesdb/converge.yml
@@ -1,0 +1,40 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: "{{ playbook_dir }}/../../../collectd-config-ansible-role"
+  vars:
+    collectd_conf_output_dir: "/etc/collectd.d"
+    collectd_typesdb_extra:
+      - name: "libpodstats"
+        path: "/etc/collectd.d"
+        types:
+          pod_cpu:
+            - ds_type: 'GAUGE'
+              min: 0
+              max: 100.1
+              ds_name: 'percent'
+            - ds_type: 'DERIVE'
+              min: 0
+              max: 'U'
+              ds_name: 'time'
+          pod_memory:
+            - ds_type: 'GAUGE'
+              min: 0
+              max: 281474976710656
+              ds_name: 'value'
+      - name: 'other_stats'
+        path: "/etc/collectd.d"
+        types:
+          messages:
+            - ds_type: 'GAUGE'
+              min: 0
+              max: 'U'
+              ds_name: 'received'
+            - ds_type: 'GAUGE'
+              min: 0
+              max: 'U'
+              ds_name: 'sent'
+    collectd_plugins:
+      - write_http
+      - cpu

--- a/molecule/extra_typesdb/molecule.yml
+++ b/molecule/extra_typesdb/molecule.yml
@@ -1,0 +1,28 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: molecule/common/requirements.yml
+driver:
+  name: ${CONTAINER_BIN:-podman}
+
+platforms:
+  - name: collectd-test
+    image: quay.io/tripleomaster/openstack-collectd:current-tripleo
+provisioner:
+  name: ansible
+  log: true
+verifier:
+  name: ansible
+
+scenario:
+  name: extra_typesdb
+  test_sequence:
+    - destroy
+    - dependency
+    - create
+    - prepare
+    - converge
+    - verify
+    - destroy
+    - cleanup

--- a/molecule/extra_typesdb/verify.yml
+++ b/molecule/extra_typesdb/verify.yml
@@ -1,0 +1,52 @@
+---
+- name: Verify
+  hosts: collectd-test
+  tasks:
+    - name: Check for files in conf output dir
+      find:
+        paths: /etc/collectd.d
+        patterns: '*.conf'
+      register: output
+      failed_when: output.files|length == 0
+
+    - name: "Check for collectd.conf"
+      find:
+        paths: /etc/
+        patterns: collectd.conf
+      register: conf
+      failed_when: conf.files|length != 1
+    - debug:
+        var: conf.files | length
+
+    - name: "Check that the TypesDB entries were added to collectd.conf"
+      slurp:
+        src: /etc/collectd.conf
+      register: conf
+      failed_when:
+        - not 'TypesDB \"/etc/collectd.d/types.db.libpodstats\"\n' in conf.content | b64decode
+        - not 'TypesDB \"/etc/collectd.d/types.db.other_stats\"\n' in conf.content | b64decode
+
+    - name: "Make sure that custom types.db.{{ item }} was created"
+      stat:
+        path: "/etc/collectd.d/types.db.{{ item }}"
+      register: typesdb_file
+      failed_when:
+        - not typesdb_file.stat.exists
+      with_items:
+        - "libpodstats"
+        - "other_stats"
+
+    - name: "Check that the types.db files are in the right format"
+      slurp:
+        src: /etc/collectd.d/types.db.libpodstats
+      register: libpodstats
+      failed_when:
+        - not "pod_cpu    percent:GAUGE:0:100.1, time:DERIVE:0:U" in libpodstats.content | b64decode
+        - not "\npod_memory value:GAUGE:0:281474976710656" in libpodstats.content | b64decode
+
+    - name: "Check that the types.db files are in the right format"
+      slurp:
+        src: /etc/collectd.d/types.db.other_stats
+      register: other_stats
+      failed_when:
+        - not "messages received:GAUGE:0:U, sent:GAUGE:0:U" in other_stats.content | b64decode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,17 @@
       dest: "{{ collectd_conf_output_dir }}/{{ item }}.conf"
       mode: 0644
     loop: "{{ collectd_plugins }}"
+
+  - name: "Create new typesdb files"
+    when: collectd_typesdb_extra is defined
+    template:
+      src: types.db.j2
+      dest: "{{ item.path }}/types.db.{{ item.name }}"
+      mode: 0644
+    vars:
+      types: "{{ item.types }}"
+    loop: "{{ collectd_typesdb_extra }}"
+
   when: templates_generate_to_disk
 
 - block:

--- a/templates/collectd.conf.j2
+++ b/templates/collectd.conf.j2
@@ -7,7 +7,10 @@ FQDNLookup true
 
 AutoLoadPlugin false
 
-TypesDB "/usr/share/collectd/types.db"{% if "libpodstats" in collectd_plugins %} "/usr/share/collectd/types.db.libpodstats"{% endif %}
+TypesDB "/usr/share/collectd/types.db"
+{% for plugin in collectd_typesdb_extra %}
+TypesDB "{{ plugin.path }}/types.db.{{ plugin.name }}"
+{% endfor %}
 
 {% if collectd_write_queue_limit_high is defined %}
 WriteQueueLimitHigh {{ collectd_write_queue_limit_high }}

--- a/templates/types.db.j2
+++ b/templates/types.db.j2
@@ -1,0 +1,4 @@
+{% for type in types %}
+{{ type }}{% for t in types[type]%} {{ [ t.ds_name, t.ds_type, t.min, t.max ] | join(":") }},{% endfor %}
+
+{% endfor %}


### PR DESCRIPTION
If plugins are not part of the collectd repo, (e.g. not written in C),
and new entries to types.db are needed, a custom types.db can be added
to collectd.conf.
This patch allows the config option collectd_typesdb_extra to be defiend
and passed to the role, which wil generate a new typesDB file and add it
to the main collectd.conf.