### PR TITLE
[ovs] Update ovs_* plugins

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -339,6 +339,20 @@ See the collectd `config guide <https://collectd.org/documentation/manpages/coll
   collectd_plugin_ntpd_reverselookups: False
   collectd_plugin_ntpd_includeunitid: True
 
+collectd_plugin_ovs_events_*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These vars are ones passed to the ``ovs_events`` plugin.
+See the collectd `config guide <https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_ovs_events>`_ for details.
+
+::
+
+  collectd_plugin_ovs_events_port: 6640
+  collectd_plugin_ovs_events_address: "127.0.0.1"
+  collectd_plugin_ovs_events_socket: "/var/run/openvswitch/db.sock"
+  collectd_plugin_ovs_events_interfaces: ["br0", "veth0"]
+  collectd_plugin_ovs_events_send_notification: true
+  collectd_plugin_ovs_events_dispatch_values: false
+
 collectd_plugin_ovs_stats_*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 These vars are ones passed to the ``ovs_stats`` plugin.
@@ -349,7 +363,7 @@ See the collectd `config guide <https://collectd.org/documentation/manpages/coll
   collectd_plugin_ovs_stats_port: 6640
   collectd_plugin_ovs_stats_address: "127.0.0.1"
   collectd_plugin_ovs_stats_socket: "/var/run/openvswitch/db.sock"
-  collectd_plugin_ovs_stats_bridges: br0 br_ext
+  collectd_plugin_ovs_stats_bridges: ["br0", "br_ext"]
 
 collectd_plugins_processes_*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/defaults/main/ovs_events.yml
+++ b/defaults/main/ovs_events.yml
@@ -1,0 +1,2 @@
+---
+collectd_plugin_ovs_events_interfaces: []

--- a/defaults/main/ovs_stats.yml
+++ b/defaults/main/ovs_stats.yml
@@ -1,0 +1,2 @@
+---
+collectd_plugin_ovs_stats_bridges: []

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -46,6 +46,7 @@
           - network
           - ntpd
           - numa
+          - ovs_events
           - ovs_stats
           - ping
           - processes

--- a/templates/ovs_events.conf.j2
+++ b/templates/ovs_events.conf.j2
@@ -1,0 +1,28 @@
+{% if collectd_plugin_ovs_events_interval is not defined %}
+LoadPlugin ovs_events
+{% else %}
+<LoadPlugin ovs_events>
+   Interval {{ collectd_plugin_ovs_events_interval }}
+</LoadPlugin>
+{% endif %}
+
+<Plugin "ovs_events">
+  {% if collectd_plugin_ovs_events_port is defined %}
+  Port {{ collectd_plugin_ovs_events_port }}
+  {% endif %}
+  {% if collectd_plugin_ovs_events_address is defined %}
+  Address "{{ collectd_plugin_ovs_events_address }}"
+  {% endif %}
+  {% if collectd_plugin_ovs_events_socket is defined %}
+  Socket "{{ collectd_plugin_ovs_events_socket }}"
+  {% endif %}
+  {% if collectd_plugin_ovs_events_interfaces | length > 0 %}
+  Interfaces "{{ collectd_plugin_ovs_events_interfaces | join('" "') }}"
+  {% endif %}
+  {% if collectd_plugin_ovs_events_send_notification is defined %}
+  SendNotification {{ collectd_plugin_ovs_events_send_notification | string | lower }}
+  {% endif %}
+  {% if collectd_plugin_ovs_events_dispatch_values is defined %}
+  DispatchValues {{ collectd_plugin_ovs_events_dispatch_values | string | lower }}
+  {% endif %}
+</Plugin>

--- a/templates/ovs_stats.conf.j2
+++ b/templates/ovs_stats.conf.j2
@@ -1,4 +1,10 @@
+{% if collectd_plugin_ovs_stats_interval is not defined %}
 LoadPlugin ovs_stats
+{% else %}
+<LoadPlugin ovs_stats>
+   Interval {{ collectd_plugin_ovs_stats_interval }}
+</LoadPlugin>
+{% endif %}
 
 <Plugin ovs_stats>
 {% if collectd_plugin_ovs_stats_port is defined %}
@@ -10,8 +16,8 @@ LoadPlugin ovs_stats
 {% if collectd_plugin_ovs_stats_socket is defined %}
   Socket "{{ collectd_plugin_ovs_stats_socket }}"
 {% endif %}
-{% if collectd_plugin_ovs_stats_bridges is defined %}
-  Bridges{% for br in collectd_plugin_ovs_stats_bridges.split(" ") %} "{{ br }}"{% endfor %}
+{% if collectd_plugin_ovs_stats_bridges | length > 0 %}
+  Bridges "{{ collectd_plugin_ovs_stats_bridges | join('" "') }}"
 {% endif %}
 
 </Plugin>

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -33,6 +33,7 @@
         - network
         - ntpd
         - numa
+        - ovs_events
         - ovs_stats
         - processes
         - procevent


### PR DESCRIPTION
Add ovs_events plugin.
Update ovs_stats to use a list of bridges instead of space separated
string, which is more in lines with other plugins.