### PR TITLE
[amqp1] Convert collectd_plugin_amqp1_instances to dict

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,19 +33,19 @@ See the collectd `config guide <https://collectd.org/documentation/manpages/coll
   collectd_plugin_amqp1_retry_delay: 1
   collectd_plugin_amqp1_send_queue_limit:
 
-  collectd_plugin_amqp1_instances: []
+  collectd_plugin_amqp1_instances: {}
   # OR
   collectd_plugin_amqp1_instances:
-     - name: "openshift-notify"
+     openshift-notify:
        format: JSON
        presettle: False
        notify: true
-     - name: "openshift-telemetry"
+     openshift-telemetry:
        format: JSON
        presettle: False
    # OR
    collectd_plugin_amqp1_instances:
-     - name: metrics
+     metrics:
        format: "Command|JSON|Graphite"
        presettle: false
        notify: false

--- a/defaults/main/amqp1.yml
+++ b/defaults/main/amqp1.yml
@@ -7,4 +7,4 @@ collectd_plugin_amqp1_port: '5672'
 collectd_plugin_amqp1_address: 'collectd'
 # collectd_plugin_amqp1_retry_delay: 1
 # collectd_plugin_amqp1_send_queue_limit:
-collectd_plugin_amqp1_instances: []
+collectd_plugin_amqp1_instances: {}

--- a/molecule/non_default_options/converge.yml
+++ b/molecule/non_default_options/converge.yml
@@ -6,6 +6,7 @@
   vars:
     collectd_conf_output_dir: "/etc/collectd.d"
     collectd_plugins:
+      - amqp1
       - connectivity
       - df
       - ethstat
@@ -17,6 +18,14 @@
       - write_http
       - write_kafka
 
+    collectd_plugin_amqp1_instances:
+      openshift-notify:
+        notify: true
+        format: JSON
+        presettle: false
+      openshift-telemetry:
+        format: JSON
+        presettle: false
     collectd_plugin_connectivity_interfaces:
       - eth0
       - eth1

--- a/molecule/non_default_options/verify.yml
+++ b/molecule/non_default_options/verify.yml
@@ -10,6 +10,7 @@
     failed_when:
       - not output.stat.exists
     with_items:
+      - amqp1
       - connectivity
       - df
       - ethstat
@@ -20,6 +21,21 @@
       - processes
       - write_http
       - write_kafka
+
+  # Check amqp1
+  - name: "Get contents of amqp1.conf"
+    slurp:
+      src: /etc/collectd.d/amqp1.conf
+    register: amqp1_conf
+
+  - debug:
+      var: amqp1_conf.content | b64decode
+
+  - name: "Check the contents of amqp1.conf"
+    assert:
+      that:
+        - '"<Instance \"openshift-notify\">\n       Format JSON\n       PreSettle false\n       Notify true\n    </Instance>\n" in amqp1_conf.content | b64decode'
+        - '"<Instance \"openshift-telemetry\">\n       Format JSON\n       PreSettle false\n    </Instance>\n" in amqp1_conf.content | b64decode'
 
   # Check connectivity
   - name: "Get contents of df.conf"

--- a/templates/amqp1.conf.j2
+++ b/templates/amqp1.conf.j2
@@ -24,36 +24,36 @@ LoadPlugin amqp1
     SendQueueLimit {{ collectd_plugin_amqp1_send_queue_limit }}
 {% endif %}
 {% for instance in collectd_plugin_amqp1_instances %}
-    <Instance "{{ instance.name }}">
-{% if "format" in instance %}
-       Format {{ instance.format }}
+    <Instance "{{ instance }}">
+{% if "format" in collectd_plugin_amqp1_instances[instance] %}
+       Format {{ collectd_plugin_amqp1_instances[instance].format }}
 {% endif %}
-{% if "presettle" in instance %}
-       PreSettle {{ instance.presettle | string | lower }}
+{% if "presettle" in collectd_plugin_amqp1_instances[instance] %}
+       PreSettle {{ collectd_plugin_amqp1_instances[instance].presettle | string | lower }}
 {% endif %}
-{% if "notify" in instance %}
-       Notify {{ instance.notify | string | lower }}
+{% if "notify" in collectd_plugin_amqp1_instances[instance] %}
+       Notify {{ collectd_plugin_amqp1_instances[instance].notify | string | lower }}
 {% endif %}
-{% if "store_rates" in instance %}
-       StoreRates {{ instance.store_rates | string | lower }}
+{% if "store_rates" in collectd_plugin_amqp1_instances[instance] %}
+       StoreRates {{ collectd_plugin_amqp1_instances[instance].store_rates | string | lower }}
 {% endif %}
-{% if "graphite_prefix" in instance %}
-       GraphitePrefix {{ instance.graphite_prefix }}
+{% if "graphite_prefix" in collectd_plugin_amqp1_instances[instance] %}
+       GraphitePrefix {{ collectd_plugin_amqp1_instances[instance].graphite_prefix }}
 {% endif %}
-{% if "graphite_postfix" in instance %}
-       GraphitePostfix {{ instance.graphite_postfix }}
+{% if "graphite_postfix" in collectd_plugin_amqp1_instances[instance] %}
+       GraphitePostfix {{ collectd_plugin_amqp1_instances[instance].graphite_postfix }}
 {% endif %}
-{% if "graphite_escape_char" in instance %}
-       GraphiteEscapeChar {{ instance.graphite_escape_char }}
+{% if "graphite_escape_char" in collectd_plugin_amqp1_instances[instance] %}
+       GraphiteEscapeChar {{ collectd_plugin_amqp1_instances[instance].graphite_escape_char }}
 {% endif %}
-{% if "graphite_separate_instances" in instance %}
-       GraphiteSeparateInstances {{ instance.graphite_separate_instances | string | lower }}
+{% if "graphite_separate_instancess" in collectd_plugin_amqp1_instances[instance] %}
+       GraphiteSeparateInstances {{ collectd_plugin_amqp1_instances[instance].graphite_separate_instances | string | lower }}
 {% endif %}
-{% if "graphite_always_append_ds" in instance %}
-       GraphiteAlwaysAppendDS {{ instance.graphite_always_append_ds | string | lower }}
+{% if "graphite_always_append_ds" in collectd_plugin_amqp1_instances[instance] %}
+       GraphiteAlwaysAppendDS {{ collectd_plugin_amqp1_instances[instance].graphite_always_append_ds | string | lower }}
 {% endif %}
-{% if "graphite_preserve_separator" in instance %}
-       GraphitePreserveSeperator {{ instance.graphite_preserve_separator | string | lower }}
+{% if "graphite_preserve_separator" in collectd_plugin_amqp1_instances[instance] %}
+       GraphitePreserveSeperator {{ collectd_plugin_amqp1_instances[instance].graphite_preserve_separator | string | lower }}
 {% endif %}
     </Instance>
 {% endfor %}


### PR DESCRIPTION
Originally, this was intended to use the same format as puppet[1], but it
was misread[2]. The format was flagged as being the incorrect format in tripleo
during testing by @csibbitt.

Now works with the expected format  i.e.

  collectd_plugin_amqp1_instances:
    openshift-notify:
      notify: true
      format: JSON
      presettle: false
    openshift-telemetry:
      format: JSON
      presettle: false

[1] https://github.com/voxpupuli/puppet-collectd/blob/eb8cfee3dc3ca20a146e2f2bc9f7a126b4404c39/templates/plugin/amqp1.conf.epp
[2] https://github.com/infrawatch/collectd-config-ansible-role/commit/312876eff5f796e16f342f3b3119bbd20335a69d